### PR TITLE
fix: update google-github-actions/setup-gcloud to v2

### DIFF
--- a/.github/workflows/regenerate.yaml
+++ b/.github/workflows/regenerate.yaml
@@ -21,7 +21,7 @@ jobs:
           credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
 
       - name: setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           version: '>= 451.0.1'
 


### PR DESCRIPTION
The actions have been failing recently, e.g. https://github.com/Kong/gke-renovate-datasource/actions/runs/12192521387

Locally the script works fine:

```
GOOGLE_LOCATION=us-central1-c ./generate-all.sh
```

This is an attempt to fix it on GHA by bumping google-github-actions/setup-gcloud to v2.